### PR TITLE
Fix check behavior when a new version is published

### DIFF
--- a/scripts/check.py
+++ b/scripts/check.py
@@ -29,13 +29,15 @@ with contextlib.redirect_stdout(sys.stderr):
     pkg_versions = [pkg.version for pkg in pkgs]
     pkg_versions.sort(key=lambda el: packaging.version.parse(el))
 
-    if not version or len(pkg_versions) == 0:
-        new_versions = pkg_versions
-    elif version not in pkg_versions:
-        new_versions = pkg_versions[-1]
+    if version not in pkg_versions:
+        # Either:
+        #   This is a fresh check (ie no 'current' version), so we return the latest version
+        #   This version is no longer available from apt, so we return the latest version
+        new_versions = pkg_versions[-1:]
     else:
+        # Otherwise, we return everything newer than the current version, including the current version
         index = pkg_versions.index(version)
-        new_versions = pkg_versions[index:-1]
+        new_versions = pkg_versions[index:]
 
     os.write(
         stdout_fd,


### PR DESCRIPTION
- Previously, the resource would report invalid versions for any version
published after the first.
- These changes bring the resource in-line with recommendations from concourse
here: https://concourse-ci.org/implementing-resource-types.html#resource-check

Co-authored-by: Patrick Oyarzun <poyarzun@pivotal.io>
Co-authored-by: John Shahid <jshahid@pivotal.io>