### PR TITLE
Fix KeyError on initial check invocation

### DIFF
--- a/scripts/check.py
+++ b/scripts/check.py
@@ -20,7 +20,7 @@ with contextlib.redirect_stdout(sys.stderr):
         print('required parameter "' + e.args[0] + '" missing')
         exit(1)
 
-    version = config['version']['id'] if config['version'] is not None else None
+    version = config['version']['id'] if 'version' in config and config['version'] is not None else None
 
     sources = apt_repo.APTSources(
         [apt_repo.APTRepository.from_sources_list_entry(repo) for repo in repos]


### PR DESCRIPTION
According to the docs here: https://concourse-ci.org/implementing-resource-types.html#resource-check

Concourse will not provide a value for the 'version' field on the initial check. After upgrading to concourse 6, my team saw the following error:

```
run check step: run check step: check: resource script '/opt/resource/check []' failed: exit status 1

stderr:
Traceback (most recent call last):
  File "/opt/resource/check", line 23, in <module>
    version = config['version']['id'] if config['version'] is not None else None
KeyError: 'version'
```

I've confirmed that this patch fixes the issue at least in concourse 6.0.0.