### PR TITLE
Add ARG for base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.6-alpine
+ARG base_image=python:3.6-alpine
+
+FROM ${base_image}
 
 RUN pip install apt-repo packaging
 


### PR DESCRIPTION
- This makes it possible to override the base image to use a local proxy cache
for example.
- This is desirable to avoid the dockerhub pull request rate limit.

Authored-by: Patrick Oyarzun <poyarzun@vmware.com>